### PR TITLE
Bugfixes and fields handling

### DIFF
--- a/pbeApp/pbexport.cpp
+++ b/pbeApp/pbexport.cpp
@@ -174,11 +174,16 @@ void transcode_samples(PBWriter& self)
 		stdString state;
 		if (self.info.getType() == CtrlInfo::Enumerated) {
 			size_t i, num = self.info.getNumStates();
-			for (i = 0; i < num; i++) {
-				self.info.getState(i,state);
-				ss.str(""); ss.clear(); ss << i;
-				fieldvalues.push_back(std::make_pair(ss.str(),state.c_str()));
+			if (num > 0) {
+				self.info.getState(0,state);
+				ss <<state.c_str();
+				for (i = 1; i < num; i++) {
+					self.info.getState(i,state);
+					ss << ";" << state.c_str();
+				}
+				fieldvalues.push_back(std::make_pair("states",ss.str()));
 			}
+
 
 		}
 	}

--- a/pbeApp/pbexport.cpp
+++ b/pbeApp/pbexport.cpp
@@ -183,12 +183,16 @@ void transcode_samples(PBWriter& self)
 				}
 				fieldvalues.push_back(std::make_pair("states",ss.str()));
 			}
-
-
 		}
 	}
 
+	CtrlInfo::Type sampleType = self.info.getType();
+
     do{
+    	if (self.info.getType() != sampleType) {
+    		std::cerr<<"The type of PV changed from " << sampleType << " to " << self.info.getType() << "\n";
+    		return;
+    	}
         sample_t *sample = (sample_t*)self.samp;
 
         if(sample->stamp.secPastEpoch>=self.endofyear.secPastEpoch) {

--- a/pbeApp/pbstreams.cpp
+++ b/pbeApp/pbstreams.cpp
@@ -65,9 +65,9 @@ void escapingarraystream::finalize()
         }
         switch(c)
         {
-        case '\n': outbuf[o++] = 1; break;
-        case '\r': outbuf[o++] = 2; break;
-        case '\x1b': outbuf[o++] = 3; break;
+        case '\x1b': outbuf[o++] = 1; break;
+        case '\n': outbuf[o++] = 2; break;
+        case '\r': outbuf[o++] = 3; break;
         }
     }
     outbuf.push_back('\n');


### PR DESCRIPTION
Fixed a bug in the line escaping.
Added the cnxlost- and cnxregained- epsecs fields.
Added the PV specific fields (HOPR, LOPR etc).
If the type of the PV changes, print an error.
